### PR TITLE
only catch tabs

### DIFF
--- a/editing.html
+++ b/editing.html
@@ -20,8 +20,8 @@
 				
 				/* Apply a return key event to each cell in the table */
 				keys.event.action( null, null, function (nCell) {
-					/* Block KeyTable from performing any events while jEditable is in edit mode */
-					keys.block = true;
+					/* Tell KeyTable it is only allowed to catch tab events while jEditable is in edit mode */
+					keys.block = 'catch-tabs';
 					
 					/* Initialise the Editable instance for this table */
 					$(nCell).editable( function (sVal) {
@@ -41,6 +41,11 @@
 					/* Dispatch click event to go into edit mode - Saf 4 needs a timeout... */
 					setTimeout( function () { $(nCell).click(); }, 0 );
 				} );
+				/* Send blur to inputs when KeyTable focus moves. */
+				keys.event.blur( null, null, function (nCell) {
+					$("input:enabled", nCell).trigger('blur');
+				} );
+
 			} );
 		</script>
 	</head>
@@ -489,9 +494,9 @@
 	
 	/* Apply a return key event to each cell in the table */
 	keys.event.action( null, null, function (nCell) {
-		/* Block KeyTable from performing any events while jEditable is in edit mode */
-		keys.block = true;
-		
+		/* Tell KeyTable it is only allowed to catch tab events while jEditable is in edit mode */
+		keys.block = 'catch-tabs';
+	
 		/* Initialise the Editable instance for this table */
 		$(nCell).editable( function (sVal) {
 			/* Submit function (local only) - unblock KeyTable */
@@ -510,6 +515,11 @@
 		/* Dispatch click event to go into edit mode - Saf 4 needs a timeout... */
 		setTimeout( function () { $(nCell).click(); }, 0 );
 	} );
+	/* Send blur to inputs when KeyTable focus moves. */
+	keys.event.blur( null, null, function (nCell) {
+		$("input:enabled", nCell).trigger('blur');
+	} );
+
 } );</pre>
 			
 			

--- a/editing.html
+++ b/editing.html
@@ -43,7 +43,9 @@
 				} );
 				/* Send blur to inputs when KeyTable focus moves. */
 				keys.event.blur( null, null, function (nCell) {
-					$("input:enabled", nCell).trigger('blur');
+					if (nCell) {
+						$("input:enabled", nCell).trigger('blur');
+					}
 				} );
 
 			} );
@@ -517,7 +519,9 @@
 	} );
 	/* Send blur to inputs when KeyTable focus moves. */
 	keys.event.blur( null, null, function (nCell) {
-		$("input:enabled", nCell).trigger('blur');
+		if (nCell) {
+			$("input:enabled", nCell).trigger('blur');
+		}
 	} );
 
 } );</pre>

--- a/js/KeyTable.js
+++ b/js/KeyTable.js
@@ -26,6 +26,8 @@ function KeyTable ( oInit )
 	 * Variable: block
 	 * Purpose:  Flag whether or not KeyTable events should be processed
 	 * Scope:    KeyTable - public
+	 * Notes:    If set to 'catch-tabs', only tab keypresses will be
+	 *           processed.
 	 */
 	this.block = false;
 	
@@ -600,7 +602,15 @@ function KeyTable ( oInit )
 	function _fnKey ( e )
 	{
 		/* If user or system has blocked KeyTable from doing anything, just ignore this event */
-		if ( _that.block || !_bKeyCapture )
+		if ( !_bKeyCapture )
+		{
+			return true;
+		}
+		// Ignore this event when blocked, *unless* the event is a
+		// tab key and we've been asked to catch those.
+		if ( _that.block &&
+		     !((_that.block === 'catch-tabs') &&
+		       (e.keyCode === 9)))
 		{
 			return true;
 		}


### PR DESCRIPTION
From http://datatables.net/forums/comments.php?DiscussionID=2630 :

> In the KeyTable + jeditable demo at http://datatables.net/release-datatables/extras/KeyTable/editing.html , when you are editing a cell and you hit "tab", it follows the document tabindex out of the table entirely (since keycapture is off during editing).

This fixes that by allowing you to set keys.block to "catch-tabs", which will block everything *except* for tab events.  The example has also been updated.
