### PR TITLE
Hotfix for RowGrouping error on click

### DIFF
--- a/js/KeyTable.js
+++ b/js/KeyTable.js
@@ -432,7 +432,23 @@ function KeyTable ( oInit )
 		if ( _oDatatable )
 		{
 			oSettings = _oDatatable.fnSettings();
-			var iRow = _fnFindDtCell( nTarget )[1];
+			var aCoords = _fnFindDtCell( nTarget );
+
+			// Confirm we have a target, RowGrouping groups will return null here
+			if ( !aCoords ) {
+				/* Undo the new highlight */
+				_fnRemoveFocus( nTarget );
+
+				/* Redo the old focus */
+				jQuery(_nOldFocus).addClass( _sFocusClass );
+				jQuery(_nOldFocus).parent().addClass( _sFocusClass );
+
+				/* @memo: Could add logic to expand containing group if its currently hidden */
+
+				return false;
+			}
+			
+			var iRow = aCoords[1];
 			var bKeyCaptureCache = _bKeyCapture;
 			
 			/* Page forwards */

--- a/js/KeyTable.js
+++ b/js/KeyTable.js
@@ -630,6 +630,24 @@ function KeyTable ( oInit )
 		
 		_fnSetFocus( nTarget );
 		_fnCaptureKeys();
+		
+		// Refresh coordinates
+		if ( _oDatatable )
+		{
+			/*
+			 * Locate the current node in the DataTable overriding the old positions - the reason for
+			 * is is that there might have been some DataTables interaction between the last focus and
+			 * now
+			 */
+			var aDtPos = _fnFindDtCell( _nOldFocus );
+			if ( aDtPos === null )
+			{
+				/* If the table has been updated such that the focused cell can't be seen - do nothing */
+				return;
+			}
+			_iOldX = aDtPos[ 0 ];
+			_iOldY = aDtPos[ 1 ];
+		}
 	}
 	
 	

--- a/js/KeyTable.js
+++ b/js/KeyTable.js
@@ -103,6 +103,8 @@ function KeyTable ( oInit )
 		{
 			_fnSetFocus( _fnCellFromCoords(x, y) );
 		}
+		
+		_refreshCoordinates();
 	};
 	
 	
@@ -630,7 +632,10 @@ function KeyTable ( oInit )
 		
 		_fnSetFocus( nTarget );
 		_fnCaptureKeys();
-		
+		_refreshCoordinates();
+	}
+
+	function _refreshCoordinates() {
 		// Refresh coordinates
 		if ( _oDatatable )
 		{


### PR DESCRIPTION
Problem: Error occurs upon clicking on group names to fold/expand with RowGrouping plugin with grouping activated

My change currently inefficiently undoes the cell change, because adding the check before cell changes would have been a more extensive change.

Problem from https://github.com/DataTables/KeyTable/issues/11