### PR TITLE
Do not retain focus if cell was removed from table

### DIFF
--- a/js/dataTables.keyTable.js
+++ b/js/dataTables.keyTable.js
@@ -248,7 +248,7 @@ $.extend( KeyTable.prototype, {
 
 			var lastFocus = that.s.lastFocus;
 
-			if ( lastFocus ) {
+			if ( lastFocus && lastFocus.node.getRootNode() === document ) {
 				var relative = that.s.lastFocus.relative;
 				var info = dt.page.info();
 				var row = relative.row + info.start;


### PR DESCRIPTION
KeyTable tries to retain focus on cells after every draw event. This is problematic if the row that contains the last-focused cell is removed in a draw.

Perhaps by chance, the code doesn't break as long as there is a row to take the place of the removed row. Focus is then moved to that row. I suppose this is a bug that became a feature.
Unfortunately the code breaks if the table is empty after a draw.

This commit fixes the problem by ensuring that the last-focused cell is still in the DOM before attempting to focus it.

PR offered under MIT