### PR TITLE
Only apply Excel style to DTE_Field_InputControl

### DIFF
--- a/js/dataTables.keyTable.js
+++ b/js/dataTables.keyTable.js
@@ -377,7 +377,7 @@ $.extend( KeyTable.prototype, {
 				editor.off( 'cancelOpen.keyTable' );
 
 				// Excel style - select all text
-				$('div.DTE input, div.DTE textarea').select();
+				$('div.DTE_Field_InputControl input, div.DTE_Field_InputControl textarea').select();
 
 				// Reduce the keys the Keys listens for
 				dt.keys.enable( that.c.editorKeys );


### PR DESCRIPTION
This commit changes the Excel style selection to only select input fields and textarea's inside a `DTE_Field_InputControl` container instead of anywhere inside its parent `DTE` container.


FYI this is the DOM structure
```html
<div class="DTE DTE_Inline">
  <div class="DTE_Inline_Field">
    <div class="DTE_Field DTE_Field_Type_{TYPE} DTE_Field_Name_{NAME} ">
      <label class="DTE_Label" for="DTE_Field_{NAME}">
        TEXT-LABEL
        <div class="DTE_Label_Info">
          TEXT-LABEL-INFO
        </div>
      </label>
      <div class="DTE_Field_Input">
        <div class="DTE_Field_InputControl">
          <input id="DTE_Field_first_name" type="text">
        </div>
        <div class="multi-value">
          MULTI-TITLE
          <span class="multi-info">
          MULTI-INFO
          </span>
        </div>
        <div class="multi-restore">
          MULTI-RESTORE
        </div>
        <div class="DTE_Field_Error">
          TEXT-FIELD-ERROR
        </div>
        <div class="DTE_Field_Message">
          TEXT-FIELD-MESSAGE
        </div>
        <div class="DTE_Field_Info">
          TEXT-FIELD-INFO
        </div>
      </div>
    </div>
  </div>
  <div class="DTE_Inline_Buttons">
    <div class="DTE_Form_Buttons">
      <button>
      TEXT-BUTTON
      </button>
      ...
    </div>
  </div>
</div>
```

PR offered under MIT terms