### PR TITLE
Calculate relative position after every draw

### DIFF
--- a/js/dataTables.keyTable.js
+++ b/js/dataTables.keyTable.js
@@ -249,7 +249,10 @@ $.extend( KeyTable.prototype, {
 			var lastFocus = that.s.lastFocus;
 
 			if ( lastFocus && lastFocus.node && $(lastFocus.node).closest('body') === document.body ) {
-				var relative = that.s.lastFocus.relative;
+				var relative = {
+					row: dt.rows( { page: 'current' } ).indexes().indexOf( lastFocus.cell.index().row ),
+					column: lastFocus.cell.index().column
+				}
 				var info = dt.page.info();
 				var row = relative.row + info.start;
 
@@ -524,11 +527,7 @@ $.extend( KeyTable.prototype, {
 		// Event and finish
 		this.s.lastFocus = {
 			cell: cell,
-			node: cell.node(),
-			relative: {
-				row: dt.rows( { page: 'current' } ).indexes().indexOf( cell.index().row ),
-				column: cell.index().column
-			}
+			node: cell.node()
 		};
 
 		this._emitEvent( 'key-focus', [ this.s.dt, cell, originalEvent || null ] );


### PR DESCRIPTION
The relative position of the last-focused cell is calculated only once when the cell is focused. This is wrong: the cell's relative position in the table can change as the result of a draw. There can be many draws between focusing and blurring a cell. KeyTable must keep track of positional changes and update the focus accordingly.

This commit changes the `draw` event handler to recalculate the relative position of `lastFocus.cell` after every draw.