### PR TITLE
Corrected issue with updating fixed column when "rightColumns" is used

### DIFF
--- a/js/dataTables.keyTable.js
+++ b/js/dataTables.keyTable.js
@@ -821,7 +821,7 @@ $.extend( KeyTable.prototype, {
 
 		if(settings._oFixedColumns){
 			var leftCols = settings._oFixedColumns.s.iLeftColumns;
-			var rightCols = settings.aoColumns.length - settings._oFixedColumns.s.iRightColumns;
+			var rightCols = settings.aoColumns.length - settings._oFixedColumns.s.iRightColumns - 1;
 			if (column < leftCols || column > rightCols)
 				dt.fixedColumns().update();
 		}


### PR DESCRIPTION
If number of columns is `5` (`settings.aoColumns.length`) and last column is fixed and `rightColumns` is `1` (`settings._oFixedColumns.s.iRightColumns`) then in order to update the last column with index `4` variable `rightCols` has to be calculated as:

```   
var rightCols = settings.aoColumns.length - settings._oFixedColumns.s.iRightColumns - 1;
```

so for the example above it would be equal to `3` (`5 - 1 - 1`) and the condition `column > rightCols` would be true.
