### PR TITLE
Revert "Calculate relative position after every draw"

### DIFF
--- a/js/dataTables.keyTable.js
+++ b/js/dataTables.keyTable.js
@@ -249,10 +249,7 @@ $.extend( KeyTable.prototype, {
 			var lastFocus = that.s.lastFocus;
 
 			if ( lastFocus && lastFocus.node && $(lastFocus.node).closest('body') === document.body ) {
-				var relative = {
-					row: dt.rows( { page: 'current' } ).indexes().indexOf( lastFocus.cell.index().row ),
-					column: lastFocus.cell.index().column
-				}
+				var relative = that.s.lastFocus.relative;
 				var info = dt.page.info();
 				var row = relative.row + info.start;
 
@@ -527,7 +524,11 @@ $.extend( KeyTable.prototype, {
 		// Event and finish
 		this.s.lastFocus = {
 			cell: cell,
-			node: cell.node()
+			node: cell.node(),
+			relative: {
+				row: dt.rows( { page: 'current' } ).indexes().indexOf( cell.index().row ),
+				column: cell.index().column
+			}
 		};
 
 		this._emitEvent( 'key-focus', [ this.s.dt, cell, originalEvent || null ] );


### PR DESCRIPTION
Reverts DataTables/KeyTable#31

Actually no - this is wrong. One of the headline features of KeyTable 2.2 was:

> New: When using client-side processing the focus will retain its relative position in the table (e.g. if cell 1,1 is focused and you jump to page 2, the visible cell 1,1 will gain focus), instead of the original cell retaining focus. This makes navigation much easier as the focus remains on screen. This behaviour now matches how KeyTable operated with server-side processing.

This change prevents that. Reverting.