### PR TITLE
fix: kt destructor and copy to cliboard condition

### DIFF
--- a/js/dataTables.keyTable.js
+++ b/js/dataTables.keyTable.js
@@ -290,7 +290,7 @@ $.extend( KeyTable.prototype, {
 		dt.on( 'destroy.keyTable', function () {
 			dt.off( '.keyTable' );
 			$( dt.table().body() ).off( 'click.keyTable', 'th, td' );
-			$( document.body )
+			$( document )
 				.off( 'keydown.keyTable' )
 				.off( 'click.keyTable' );
 		} );
@@ -629,7 +629,7 @@ $.extend( KeyTable.prototype, {
 			return;
 		}
 
-		if ( e.ctrlKey && e.keyCode === 67 ) { // c
+		if ( e.ctrlKey && !e.altKey && e.keyCode === 67 ) { // c
 			this._clipboardCopy();
 			return;
 		}


### PR DESCRIPTION
First of all, click and keydown events are bound to document and destroying table unbinds them for document.body.

As for second issue, pressing alt gr + c causes execution of _clipboardCopy method as e.ctrlKey is true in some browsers (at least on IE11, FF57, Chrome 61) . It prevents user from typing special character associated with alt gr + c (eg. polish ć) combination when doing simple inline editing. Addditional check if e.altKey is true seems to be fixing this issue.