### PR TITLE
Fixed errors caused by focusing filtered out rows.

### DIFF
--- a/js/dataTables.keyTable.js
+++ b/js/dataTables.keyTable.js
@@ -599,6 +599,11 @@ $.extend( KeyTable.prototype, {
 				.rows( { filter: 'applied', order: 'applied' } )
 				.indexes()
 				.indexOf( index.row );
+			
+			// Don't focus rows that were filtered out.
+			if ( row < 0 ) {
+				return;
+			}
 
 			// For server-side processing normalise the row by adding the start
 			// point, since `rows().indexes()` includes only rows that are


### PR DESCRIPTION
Changing the search filter while a cell is focused, in such a way that the cell's row gets filtered out, leaves the saved state pointing to a row that was filtered out. When such a state is loaded, the attempt to focus the row that was filtered out causes errors. This change should simply ignore such invalid states.