### PR TITLE
Update dataTables.keyTable.js

### DIFF
--- a/js/dataTables.keyTable.js
+++ b/js/dataTables.keyTable.js
@@ -830,6 +830,10 @@ $.extend( KeyTable.prototype, {
 		if ( (e.keyCode === 0 || e.ctrlKey || e.metaKey || e.altKey) && !(e.ctrlKey && e.altKey) ) {
 			return;
 		}
+		
+		if(document.activeElement && document.activeElement.tagName.toLowerCase() !== 'body') {
+			return;
+		}
 
 		// If not focused, then there is no key action to take
 		var lastFocus = this.s.lastFocus;


### PR DESCRIPTION
If the user is focused on an element that isn't the body then button events should be ignored. I had users that had their tab events intercepted instead of tabbing to the next input. If the user has an input, button, etc focused the keys should be ignored.

I first had it just ignore if the event target was an input, select, etc. Problem with this approach I kept finding more elements that needed to be ignored. Matching on the body element seems to future proof this.